### PR TITLE
Remove unneeded call to and other style changes

### DIFF
--- a/routes/instructor_routes.js
+++ b/routes/instructor_routes.js
@@ -2,46 +2,45 @@
 
 const bodyParser = require('koa-bodyparser');
 const instructorRouter = require('koa-router')();
-const instructorModel = require(__dirname + '/../models/instructor');
+const Instructor = require(__dirname + '/../models/instructor');
 const errorHandler = require(__dirname + '/../lib/error_handler');
 
 module.exports = exports = instructorRouter
   .get('/instructors', function* () {
     try {
-      const data = yield instructorModel.find({}).exec();
-      this.response.status = 200;
-      this.response.body = data;
+      var data = yield Instructor.find({}).exec();
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = data;
   })
   .post('/instructors', bodyParser(), function* () {
-    const newInstructor = yield instructorModel.create(this.request.body);
     try {
-      const data = yield newInstructor.save();
-      this.response.status = 200;
-      this.response.body = data;
+      var data = yield Instructor.create(this.request.body);
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = data;
   })
   .put('/instructors/:id', bodyParser(), function* () {
     const putBody = this.request.body;
     delete putBody._id;
     try {
-      yield instructorModel.update({ _id: this.params.id }, putBody).exec();
-      this.response.status = 200;
-      this.response.body = { msg: 'success' };
+      yield Instructor.update({ _id: this.params.id }, putBody).exec();
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = { msg: 'success' };
   })
   .delete('/instructors/:id', function* () {
     try {
-      yield instructorModel.remove({ _id: this.params.id });
-      this.response.status = 200;
-      this.response.body = { msg: 'success' };
+      yield Instructor.remove({ _id: this.params.id });
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = { msg: 'success' };
   });

--- a/routes/student_routes.js
+++ b/routes/student_routes.js
@@ -2,46 +2,45 @@
 
 const bodyParser = require('koa-bodyparser');
 const studentRouter = require('koa-router')();
-const studentModel = require(__dirname + '/../models/student');
+const Student = require(__dirname + '/../models/student');
 const errorHandler = require(__dirname + '/../lib/error_handler');
 
 module.exports = exports = studentRouter
   .get('/students', function* () {
     try {
-      const data = yield studentModel.find({}).exec();
-      this.response.status = 200;
-      this.response.body = data;
+      var data = yield Student.find({}).exec();
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = data;
   })
   .post('/students', bodyParser(), function* () {
-    const newStudent = yield studentModel.create(this.request.body);
     try {
-      const data = yield newStudent.save();
-      this.response.status = 200;
-      this.response.body = data;
+      var data = yield Student.create(this.request.body);
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = data;
   })
   .put('/students/:id', bodyParser(), function* () {
     const putBody = this.request.body;
     delete putBody._id;
     try {
-      yield studentModel.update({ _id: this.params.id }, putBody).exec();
-      this.response.status = 200;
-      this.response.body = { msg: 'success' };
+      yield Student.update({ _id: this.params.id }, putBody).exec();
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = { msg: 'success' };
   })
   .delete('/students/:id', function* () {
     try {
-      yield studentModel.remove({ _id: this.params.id });
-      this.response.status = 200;
-      this.response.body = { msg: 'success' };
+      yield Student.remove({ _id: this.params.id });
     } catch (e) {
       errorHandler(e).bind(this);
     }
+    this.response.status = 200;
+    this.response.body = { msg: 'success' };
   });

--- a/test/instructors.spec.js
+++ b/test/instructors.spec.js
@@ -12,7 +12,7 @@ const request = chai.request;
 require(__dirname + '/../server');
 
 describe('Instructor API', () => {
-  it('should make a valid GET request at /instructors', (done) => {
+  it('should make a valid GET request at /instructors', done => {
     request('localhost:3000')
       .get('/api/instructors')
       .end((err, res) => {
@@ -21,7 +21,7 @@ describe('Instructor API', () => {
         done();
       });
   });
-  it('should make a valid POST request at /instructors', (done) => {
+  it('should make a valid POST request at /instructors', done => {
     request('localhost:3000')
       .post('/api/instructors')
       .send({ name: 'Tyler', facialHair: false })


### PR DESCRIPTION
When using `Model.create` a separate all to `save` is not needed. You only call save when using the model constructor.
